### PR TITLE
Remove hardcoded 1.3.0 reference in mix task docs

### DIFF
--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -20,7 +20,7 @@ mix phx.gen.json       # Generates controller, views, and context for a JSON res
 mix phx.gen.presence   # Generates a Presence tracker
 mix phx.gen.schema     # Generates an Ecto schema and migration file
 mix phx.gen.secret     # Generates a secret
-mix phx.new            # Creates a new Phoenix v1.3.0 application
+mix phx.new            # Creates a new Phoenix application
 mix phx.new.ecto       # Creates a new Ecto project within an umbrella project
 mix phx.new.web        # Creates a new Phoenix web project within an umbrella project
 mix phx.routes         # Prints all routes


### PR DESCRIPTION
Phoenix Specific Mix Tasks guide has a reference to generating a 1.3.0 application with `phx.new` task.

This change removes the specific version so the docs stay accurate.

<img width="852" alt="screen shot 2018-10-13 at 11 47 21" src="https://user-images.githubusercontent.com/33321/46908853-da474c00-cedd-11e8-9a03-5ab2478ae05d.png">

https://hexdocs.pm/phoenix/1.4.0-rc.1/phoenix_mix_tasks.html#phoenix-specific-mix-tasks